### PR TITLE
Allow mismatching PatientIDs when transferring a study

### DIFF
--- a/adit/batch_query/processors.py
+++ b/adit/batch_query/processors.py
@@ -25,6 +25,11 @@ class BatchQueryTaskProcessor(DicomTaskProcessor):
         self.operator = DicomOperator(source.dicomserver)
 
     def process(self) -> ProcessingResult:
+        # TODO: Allow to get multiple patients (but provide a warning if there are multiple
+        # patients). We also have to use a for loop then. Make sure that users that provide
+        # only a patient name must provide a birth date as well.
+        # Also make sure that patient name doesn't contain wildcards.
+
         patient = self._fetch_patient()
 
         is_series_query = self.query_task.series_description or self.query_task.series_numbers
@@ -43,8 +48,6 @@ class BatchQueryTaskProcessor(DicomTaskProcessor):
         for log in logs:
             if log["level"] == "Warning":
                 status = BatchQueryTask.Status.WARNING
-
-        self.operator.clear_logs()
 
         return {
             "status": status,

--- a/adit/core/tests/test_workers.py
+++ b/adit/core/tests/test_workers.py
@@ -1,5 +1,6 @@
 import datetime
 from time import sleep
+from typing import override
 
 import pytest
 import time_machine
@@ -9,6 +10,7 @@ from adit.core.errors import RetriableDicomError
 
 from ..models import DicomJob, DicomTask, QueuedTask
 from ..processors import DicomTaskProcessor
+from ..types import ProcessingResult
 from ..workers import DicomWorker
 from .example_app.factories import ExampleTransferJobFactory, ExampleTransferTaskFactory
 from .example_app.models import ExampleAppSettings, ExampleTransferTask
@@ -18,6 +20,14 @@ class ExampleProcessor(DicomTaskProcessor):
     app_name = "Example"
     dicom_task_class = ExampleTransferTask
     app_settings_class = ExampleAppSettings
+
+    @override
+    def process(self) -> ProcessingResult:
+        return {
+            "status": ExampleTransferTask.Status.SUCCESS,
+            "message": "Example task succeeded",
+            "log": "",
+        }
 
 
 @pytest.fixture(autouse=True)

--- a/adit/core/types.py
+++ b/adit/core/types.py
@@ -22,6 +22,7 @@ class AuthenticatedApiRequest(Request):
 
 class DicomLogEntry(TypedDict):
     level: Literal["Info", "Warning"]
+    title: str
     message: str
 
 

--- a/adit/core/utils/dicom_dataset.py
+++ b/adit/core/utils/dicom_dataset.py
@@ -139,7 +139,7 @@ class _NoValue:
 
 class QueryDataset(BaseDataset):
     def ensure_elements(self, *keywords: str) -> None:
-        """Ensure that specific elements in a dataset are present."""
+        """Ensure that specific elements in a dataset are present (even if empty)."""
         for keyword in keywords:
             if keyword not in self._ds:
                 setattr(self._ds, keyword, "")

--- a/adit/core/utils/dicom_operator.py
+++ b/adit/core/utils/dicom_operator.py
@@ -65,14 +65,22 @@ class DicomOperator:
     def get_logs(self) -> list[DicomLogEntry]:
         return self.dimse_connector.logs + self.dicom_web_connector.logs + self.logs
 
-    def clear_logs(self) -> None:
-        self.dimse_connector.logs.clear()
-        self.dicom_web_connector.logs.clear()
-        self.logs.clear()
-
     def abort(self) -> None:
         self.dimse_connector.abort_connection()
         self.dicom_web_connector.abort()
+
+    def find_patient_id_of_study_uid(self, study_uid: str) -> str | None:
+        query = QueryDataset.create(StudyInstanceUID=study_uid, QueryRetrieveLevel="STUDY")
+        result: ResultDataset | None = None
+        if self.server.study_root_find_support:
+            result = next(self.dimse_connector.send_c_find(query), None)
+        elif self.server.dicomweb_qido_support:
+            result = next(iter(self.dicom_web_connector.send_qido_rs(query)), None)
+
+        if result and "PatientID" in result:
+            return result.PatientID
+
+        return None
 
     def find_patients(
         self,
@@ -625,6 +633,7 @@ class DicomOperator:
                     self.logs.append(
                         {
                             "level": "Warning",
+                            "title": "Some images could not be fetched",
                             "message": "Failed to fetch some images with C-MOVE.",
                         }
                     )

--- a/adit/core/utils/dimse_connector.py
+++ b/adit/core/utils/dimse_connector.py
@@ -431,17 +431,35 @@ class DimseConnector:
 
                     if failed_suboperations and completed_suboperations:
                         message = f"{failed_suboperations} sub-operations failed:\n{status}"
-                        self.logs.append({"level": "Warning", "message": message})
+                        self.logs.append(
+                            {
+                                "level": "Warning",
+                                "title": "Some failed sub-operations",
+                                "message": message,
+                            }
+                        )
                         logger.warn(message)
 
                     if warning_suboperations:
                         message = f"{warning_suboperations} sub-operations with warnings."
-                        self.logs.append({"level": "Warning", "message": message})
+                        self.logs.append(
+                            {
+                                "level": "Warning",
+                                "title": "Sub-operations with warnings",
+                                "message": message,
+                            }
+                        )
                         logger.warn(message)
                 else:
                     if status_category == STATUS_WARNING:
                         message = f"Unknown warning:\n{status}"
-                        self.logs.append({"level": "Warning", "message": message})
+                        self.logs.append(
+                            {
+                                "level": "Warning",
+                                "title": "Unexpected warnings",
+                                "message": message,
+                            }
+                        )
                         logger.warn(message)
 
             if status_category == STATUS_FAILURE:


### PR DESCRIPTION
A PatientID may change when this is an external study and it was re-assigned to another already known patient.