### PR TITLE
Handle missing non-mandatory series level tags in file writing

### DIFF
--- a/adit/core/processors.py
+++ b/adit/core/processors.py
@@ -313,7 +313,15 @@ class TransferTaskProcessor(DicomTaskProcessor):
 
             final_folder: Path
             if settings.CREATE_SERIES_SUB_FOLDERS:
-                series_folder_name = sanitize_filename(f"{ds.SeriesNumber}-{ds.SeriesDescription}")
+                series_number = ds.get("SeriesNumber", "")
+                if series_number == "":
+                    series_folder_name = ds.SeriesInstanceUID
+                else:
+                    series_description = ds.get("SeriesDescription", "")
+                    if series_description == "":
+                        series_description = "Undefined"
+                    series_folder_name = f"{series_number}-{series_description}"
+                series_folder_name = sanitize_filename(series_folder_name)
                 final_folder = study_folder / series_folder_name
             else:
                 final_folder = study_folder

--- a/adit/core/processors.py
+++ b/adit/core/processors.py
@@ -313,13 +313,11 @@ class TransferTaskProcessor(DicomTaskProcessor):
 
             final_folder: Path
             if settings.CREATE_SERIES_SUB_FOLDERS:
-                series_number = ds.get("SeriesNumber", "")
-                if series_number == "":
+                series_number = ds.get("SeriesNumber")
+                if not series_number:
                     series_folder_name = ds.SeriesInstanceUID
                 else:
-                    series_description = ds.get("SeriesDescription", "")
-                    if series_description == "":
-                        series_description = "Undefined"
+                    series_description = ds.get("SeriesDescription", "Undefined")
                     series_folder_name = f"{series_number}-{series_description}"
                 series_folder_name = sanitize_filename(series_folder_name)
                 final_folder = study_folder / series_folder_name


### PR DESCRIPTION
Pydicom dataset.SeriesDescription raises AttributeError if tag does not exist, which is rare, but possible and also allowed according to dicom standard, therefore needs to be handled correctly.