### PR TITLE
Remove race condition mock test

### DIFF
--- a/adit/dicom_web/tests/utils/test_wado_retrieve.py
+++ b/adit/dicom_web/tests/utils/test_wado_retrieve.py
@@ -250,49 +250,9 @@ async def test_wado_retrieve_with_non_retriable_error(monkeypatch):
 
 
 """
-Mock tests simulating the race condition in the old implementation and 
+Mock test simulating the race condition in the old implementation and 
 how adding a sentinel resolves it. Can be removed if deemed unnecessary.
 """
-
-
-@pytest.mark.asyncio
-async def test_race_condition():
-    results = []
-
-    async def wado_retrieve_rc():
-        queue = asyncio.Queue()
-
-        async def fetch():
-            for i in range(3):
-                # simulate fetch_study that takes some time, allowing queue_get_task to run
-                await asyncio.sleep(0.0001)
-                queue.put_nowait(i)
-
-        fetch_task = asyncio.create_task(fetch())
-
-        while True:
-            queue_get_task = asyncio.create_task(queue.get())
-            done, _ = await asyncio.wait(
-                [fetch_task, queue_get_task], return_when=asyncio.FIRST_COMPLETED
-            )
-
-            finished = False
-            for task in done:
-                if task == queue_get_task:
-                    results.append(queue_get_task.result())
-                    # artificial delay after queue_get_task, allowing fetch_task to finish
-                    # before the final queue_get_task can run
-                    await asyncio.sleep(0.0003)
-                if task == fetch_task:
-                    finished = True
-
-            if finished:
-                queue_get_task.cancel()
-                break
-
-    await wado_retrieve_rc()
-
-    assert results == [0, 1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This test was initially created to simulate the race condition in the previous implementation of wado_retrieve. The race condition case happens when the producer's fetch_task finishes before the consumer's queue_get_task finishes. This was simulated by introducing an artificial delay after the previous queue_get_task which does not reliably result in the race condition every time. Since the new implementation resolves the race condition with a sentinel in any case, the simulated test is no longer necessary.