### PR TITLE
Make Postgres wait timeout configurable

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,7 +34,7 @@ services:
       - ${REMOTE_DEBUGGING_PORT:-5678}:5678
     command: >
       bash -c "
-        wait-for-it -s postgres.local:5432 -t 60 && 
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py migrate &&
         ./manage.py create_superuser &&
         ./manage.py create_example_users &&
@@ -53,7 +53,7 @@ services:
     image: adit_dev-default_worker:latest
     command: >
       bash -c "
-        wait-for-it -s postgres.local:5432 -t 60 &&
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py bg_worker -l debug -q default --autoreload
       "
 
@@ -62,7 +62,7 @@ services:
     image: adit_dev-dicom_worker:latest
     command: >
       bash -c "
-        wait-for-it -s postgres.local:5432 -t 60 &&
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py bg_worker -l debug -q dicom --autoreload
       "
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,7 +26,7 @@ services:
     hostname: init.local
     command: >
       bash -c "
-        wait-for-it -s postgres.local:5432 -t 60 && 
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py migrate &&
         ./manage.py collectstatic --no-input &&
         ./manage.py create_superuser &&
@@ -61,7 +61,7 @@ services:
     <<: *default-app
     command: >
       bash -c "
-        wait-for-it -s postgres.local:5432 -t 60 &&
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py bg_worker -q default
       "
     deploy:
@@ -71,7 +71,7 @@ services:
     <<: *default-app
     command: >
       bash -c "
-        wait-for-it -s postgres.local:5432 -t 60 &&
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py bg_worker -q dicom
       "
     deploy:


### PR DESCRIPTION
## Summary

- Replace hard-coded `wait-for-it` timeouts with configurable `WAIT_POSTGRES_TIMEOUT` environment variable across all docker-compose files
- Default is 180 seconds, overridable via `.env`

See also openradx/radis#212

## Test plan

- [ ] Verify `docker compose config` correctly interpolates the default (180s) when `WAIT_POSTGRES_TIMEOUT` is unset
- [ ] Verify setting `WAIT_POSTGRES_TIMEOUT=300` in `.env` overrides all `wait-for-it` calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application startup configuration with parameterized database readiness timeout across development and production environments, enabling deployment customization to accommodate varying database initialization speeds and environment-specific requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->