### PR TITLE
feat: migrate to django-dbbackup 5.3+ and use shared backup_db task

### DIFF
--- a/adit/core/tasks.py
+++ b/adit/core/tasks.py
@@ -8,7 +8,6 @@ from typing import cast
 import pglock
 from django import db
 from django.conf import settings
-from django.core.management import call_command
 from django.utils import timezone
 from pebble import ProcessFuture, concurrent
 from procrastinate import JobContext, RetryStrategy
@@ -45,12 +44,6 @@ def check_disk_space(*args, **kwargs):
             )
             logger.warning(msg)
             send_mail_to_admins("Warning, low disk space!", msg)
-
-
-@app.periodic(cron="0 3 * * * ")  # every day at 3am
-@app.task
-def backup_db(*args, **kwargs):
-    call_command("dbbackup", "--clean", "-v 2")
 
 
 DICOM_TASK_RETRY_STRATEGY = RetryStrategy(

--- a/adit/settings/base.py
+++ b/adit/settings/base.py
@@ -340,12 +340,24 @@ CODEMIRROR_CONFIG = {
 # Cave, changing the salt after some tokens were already generated makes them all invalid!
 TOKEN_AUTHENTICATION_SALT = env.str("TOKEN_AUTHENTICATION_SALT")
 
-# django-dbbackup
-DBBACKUP_STORAGE = "django.core.files.storage.FileSystemStorage"
-DBBACKUP_STORAGE_OPTIONS = {
-    "location": env.str("DBBACKUP_STORAGE_LOCATION", default="/tmp/backups-adit")
+# Django default storage and django-dbbackup
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+    "dbbackup": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+        "OPTIONS": {
+            "location": env.str("DBBACKUP_STORAGE_LOCATION", default="/tmp/backups-adit")
+        },
+    },
 }
 DBBACKUP_CLEANUP_KEEP = 30
+BACKUP_ENABLED = env.bool("BACKUP_ENABLED", default=True)
+BACKUP_CRON = env.str("BACKUP_CRON", default="0 3 * * *")
 
 # Orthanc servers are integrated in ADIT by using a reverse proxy (django-revproxy).
 ORTHANC1_HOST = env.str("ORTHANC1_HOST", default="localhost")

--- a/adit/settings/production.py
+++ b/adit/settings/production.py
@@ -12,13 +12,8 @@ DATABASES["default"]["PASSWORD"] = env.str("POSTGRES_PASSWORD")  # noqa: F405
 
 STATIC_ROOT = env.str("DJANGO_STATIC_ROOT")
 
-STORAGES = {
-    "default": {
-        "BACKEND": "django.core.files.storage.FileSystemStorage",
-    },
-    "staticfiles": {
-        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
-    },
+STORAGES["staticfiles"] = {  # noqa: F405
+    "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
 }
 
 SECURE_SSL_REDIRECT = env.bool("DJANGO_SECURE_SSL_REDIRECT")

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -5,6 +5,8 @@ x-app: &default-app
   depends_on:
     - postgres
   environment:
+    BACKUP_CRON: ${BACKUP_CRON:-0 3 * * *}
+    BACKUP_ENABLED: ${BACKUP_ENABLED:-true}
     CALLING_AE_TITLE: ${CALLING_AE_TITLE:?}
     DATABASE_URL: postgres://postgres:postgres@postgres.local:5432/postgres
     DBBACKUP_STORAGE_LOCATION: /backups

--- a/example.env
+++ b/example.env
@@ -71,6 +71,13 @@ SUPERUSER_AUTH_TOKEN="your_superuser_auth_token_here"
 # Location of the backup folder.
 BACKUP_DIR="/tmp/backups"
 
+# Enable the daily database backup periodic task.
+# Set to "false" to no-op the shared backup_db task (e.g. in test environments).
+BACKUP_ENABLED=true
+
+# Cron schedule for the shared backup_db periodic task.
+BACKUP_CRON="0 3 * * *"
+
 # Site information that is synced to the database and used by the sites framework.
 SITE_NAME="ADIT"
 SITE_DOMAIN=localhost

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.0.0"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
 dependencies = [
-    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.21.0",
+    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.22.0",
     "adrf>=0.1.9",
     "aiofiles>=24.1.0",
     "asyncinotify>=4.2.0",
@@ -23,7 +23,7 @@ dependencies = [
     "django-codemirror>=1.0.1",
     "django-cotton>=1.6.0",
     "django-crispy-forms>=2.3",
-    "django-dbbackup>=4.2.1",
+    "django-dbbackup>=5.3.0",
     "django-extensions>=3.2.3",
     "django-filter>=25.1",
     "django-htmx>=1.22.0",

--- a/uv.lock
+++ b/uv.lock
@@ -104,7 +104,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.21.0" },
+    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.22.0" },
     { name = "adrf", specifier = ">=0.1.9" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "asyncinotify", specifier = ">=4.2.0" },
@@ -120,7 +120,7 @@ requires-dist = [
     { name = "django-codemirror", specifier = ">=1.0.1" },
     { name = "django-cotton", specifier = ">=1.6.0" },
     { name = "django-crispy-forms", specifier = ">=2.3" },
-    { name = "django-dbbackup", specifier = ">=4.2.1" },
+    { name = "django-dbbackup", specifier = ">=5.3.0" },
     { name = "django-extensions", specifier = ">=3.2.3" },
     { name = "django-filter", specifier = ">=25.1" },
     { name = "django-htmx", specifier = ">=1.22.0" },
@@ -213,7 +213,7 @@ requires-dist = [
 [[package]]
 name = "adit-radis-shared"
 version = "0.0.0"
-source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.21.0#f27d2f03c186703765409ae83baae126108dd0ec" }
+source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.22.0#a09a820724140f9da02d56661864d55c126128e4" }
 dependencies = [
     { name = "channels" },
     { name = "crispy-bootstrap5" },
@@ -948,14 +948,14 @@ wheels = [
 
 [[package]]
 name = "django-dbbackup"
-version = "5.1.1"
+version = "5.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/a1/3416a388b58b0b1d3256575f99e3a7b0db9fd3ce44086b3f7a2eb40515a6/django_dbbackup-5.1.1.tar.gz", hash = "sha256:bfefa6fcf64a602fd5416bc7fff679509bf7eee35c114eee295730df8e9589c9", size = 26371, upload-time = "2026-01-08T05:32:50.719Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/8b/6a963f6e3d13eb689a842c8d942a22bd0f477f328c1ce98e40334ac0031b/django_dbbackup-5.3.0.tar.gz", hash = "sha256:2c880dba7650539e8a724174fedb5213062c4fcda3aa09e1c5f3f573192106cb", size = 27843, upload-time = "2026-04-10T01:49:43.02Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/dd/e4d197dacb333a30b5756b0a059f84d0e27e7b2b694365caf145896de390/django_dbbackup-5.1.1-py3-none-any.whl", hash = "sha256:371d82803743f6963d7d6d44ee145472213ddd287c43576ddbc11f2277972c1d", size = 34626, upload-time = "2026-01-08T05:32:49.191Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fa/24891c73c6fc76e6005389a496fa1752a69d6ff8c609692f86513ab373ad/django_dbbackup-5.3.0-py3-none-any.whl", hash = "sha256:ff80b5facd524e3f6479235aeb330b094a1c982f8b0b9503c24ba0dc613162ed", size = 36170, upload-time = "2026-04-10T01:49:41.534Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `adit-radis-shared` to `0.22.0` (which adds a shared `backup_db` periodic task with `BACKUP_ENABLED` and `BACKUP_CRON` env knobs).
- Bump `django-dbbackup` to `>=5.3.0`.
- Migrate `adit/settings/base.py` to the new `STORAGES["dbbackup"]` format. Legacy `DBBACKUP_STORAGE` / `DBBACKUP_STORAGE_OPTIONS` raise at import time in 5.3+. Add `BACKUP_ENABLED` and `BACKUP_CRON` settings.
- Migrate `adit/settings/production.py` from a full-replacement `STORAGES = {…}` to a single targeted `STORAGES["staticfiles"]` override; preserves `default` and `dbbackup` from base.
- Drop the local `backup_db` from `adit/core/tasks.py`. Procrastinate auto-discovers the shared task via `adit_radis_shared.common`. Remove the now-unused `call_command` import.

Supersedes #329.

## Test plan
- [x] `uv run cli lint` passes (70 files, 0 errors)
- [x] `adit.settings.test` imports cleanly under dbbackup 5.3.0; `STORAGES` has expected three keys; `dbbackup` location resolves to `/tmp/backups-adit`; `import dbbackup.settings` does not raise
- [x] `adit.settings.production` imports cleanly with whitenoise staticfiles override merged into the inherited STORAGES dict
- [x] `adit_radis_shared.common.tasks.backup_db` is reachable; `adit.core.tasks.backup_db` is gone
- [ ] Manual end-to-end `./manage.py dbbackup --clean -v 2` against the dev stack (deferred — local docker buildx-bake build is hitting an unrelated Dockerfile-resolution issue with the worker service; will be addressed separately)