### PR TITLE
Pass Django and Psycopg instrumentors explicitly to setup_opentelemetry

### DIFF
--- a/adit/asgi.py
+++ b/adit/asgi.py
@@ -16,8 +16,10 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "adit.settings.development")
 
 # Initialize OpenTelemetry before Django loads to ensure all requests are traced
 from adit_radis_shared.telemetry import setup_opentelemetry  # noqa: E402
+from opentelemetry.instrumentation.django import DjangoInstrumentor  # noqa: E402
+from opentelemetry.instrumentation.psycopg import PsycopgInstrumentor  # noqa: E402
 
-setup_opentelemetry()
+setup_opentelemetry(instrumentors=[DjangoInstrumentor, PsycopgInstrumentor])
 
 from channels.security.websocket import AllowedHostsOriginValidator  # noqa: E402
 from channels.sessions import SessionMiddlewareStack  # noqa: E402

--- a/manage.py
+++ b/manage.py
@@ -25,8 +25,10 @@ def main():
 
     # Initialize OpenTelemetry before Django loads to ensure all requests are traced
     from adit_radis_shared.telemetry import setup_opentelemetry
+    from opentelemetry.instrumentation.django import DjangoInstrumentor
+    from opentelemetry.instrumentation.psycopg import PsycopgInstrumentor
 
-    setup_opentelemetry()
+    setup_opentelemetry(instrumentors=[DjangoInstrumentor, PsycopgInstrumentor])
 
     initialize_debugger()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,12 @@ version = "0.0.0"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
 dependencies = [
-    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.23.0",
+    # The [django] extra carries opentelemetry-instrumentation-django and
+    # -psycopg, which are imported in manage.py / adit/asgi.py and passed to
+    # setup_opentelemetry(instrumentors=[...]). Non-Django consumers of
+    # adit-radis-shared install the bare package and pass their own
+    # instrumentor list (or none).
+    "adit-radis-shared[django] @ git+https://github.com/openradx/adit-radis-shared.git@0.24.0",
     "adrf>=0.1.9",
     "aiofiles>=24.1.0",
     "asyncinotify>=4.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ name = "adit"
 version = "0.0.0"
 source = { editable = "." }
 dependencies = [
-    { name = "adit-radis-shared" },
+    { name = "adit-radis-shared", extra = ["django"] },
     { name = "adrf" },
     { name = "aiofiles" },
     { name = "asyncinotify" },
@@ -104,7 +104,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.23.0" },
+    { name = "adit-radis-shared", extras = ["django"], git = "https://github.com/openradx/adit-radis-shared.git?rev=0.24.0" },
     { name = "adrf", specifier = ">=0.1.9" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "asyncinotify", specifier = ">=4.2.0" },
@@ -213,7 +213,7 @@ requires-dist = [
 [[package]]
 name = "adit-radis-shared"
 version = "0.0.0"
-source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.23.0#2ea948f4492496de1c65f4aad04a603c1175d83a" }
+source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.24.0#39955cf5dbb2fd8ab421a5bfb404d518b39d14ec" }
 dependencies = [
     { name = "channels" },
     { name = "crispy-bootstrap5" },
@@ -236,8 +236,6 @@ dependencies = [
     { name = "environs", extra = ["django"] },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation-django" },
-    { name = "opentelemetry-instrumentation-psycopg" },
     { name = "opentelemetry-sdk" },
     { name = "procrastinate", extra = ["django"] },
     { name = "psycopg", extra = ["binary"] },
@@ -247,6 +245,12 @@ dependencies = [
     { name = "wait-for-it" },
     { name = "watchfiles" },
     { name = "whitenoise" },
+]
+
+[package.optional-dependencies]
+django = [
+    { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-instrumentation-psycopg" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adopts the new pluggable-instrumentor API from adit-radis-shared so the helper no longer hard-codes Django/Psycopg.

- `manage.py` and `adit/asgi.py` import DjangoInstrumentor and PsycopgInstrumentor and pass them as `instrumentors=[...]`.
- `pyproject.toml` requests the `[django]` extra of adit-radis-shared (which carries the two instrumentor packages) and bumps the pin to 0.24.0.

Behaviour at runtime is identical to today.

## Depends on

- openradx/adit-radis-shared#195 (must merge first, and the 0.24.0 tag must be cut from the resulting main)

## Test plan

- [ ] After adit-radis-shared#195 merges and the 0.24.0 tag is pushed: run `uv lock --upgrade-package adit-radis-shared` and commit the lock update on this branch.
- [ ] CI should pass (Django boots, web requests still produce traces, Psycopg still produces DB spans).
- [ ] Eyeball OpenObserve after deploy: `service.name=adit-*` still emitting traces/metrics/logs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)