### PR TITLE
Drop `from __future__ import annotations` from mass_transfer

### DIFF
--- a/adit/mass_transfer/forms.py
+++ b/adit/mass_transfer/forms.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import secrets
 from typing import Annotated, Literal, cast

--- a/adit/mass_transfer/models.py
+++ b/adit/mass_transfer/models.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import secrets
 from typing import TYPE_CHECKING
@@ -61,14 +59,14 @@ class MassTransferJob(TransferJob):
             return json.dumps(self.filters_json, indent=2)
         return ""
 
-    def get_filters(self) -> list[FilterSpec]:
+    def get_filters(self) -> list["FilterSpec"]:
         from .processors import FilterSpec
 
         if not self.filters_json:
             return []
         return [FilterSpec.from_dict(d) for d in self.filters_json]
 
-    tasks: models.QuerySet[MassTransferTask]
+    tasks: models.QuerySet["MassTransferTask"]
 
     def get_absolute_url(self):
         return reverse("mass_transfer_job_detail", args=[self.pk])
@@ -100,7 +98,7 @@ class MassTransferTask(TransferTask):
     partition_end = models.DateTimeField()
     partition_key = models.CharField(max_length=64)
 
-    volumes: models.QuerySet[MassTransferVolume]
+    volumes: models.QuerySet["MassTransferVolume"]
 
     class Meta:
         constraints = [

--- a/adit/mass_transfer/processors.py
+++ b/adit/mass_transfer/processors.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import logging
 import secrets
@@ -54,7 +52,7 @@ class FilterSpec:
     min_number_of_series_related_instances: int | None = None
 
     @classmethod
-    def from_dict(cls, d: dict) -> FilterSpec:
+    def from_dict(cls, d: dict) -> "FilterSpec":
         mode = d.get("mode", "include")
         if mode not in ("include", "exclude"):
             raise DicomError(f"Invalid filter mode: {mode!r}")

--- a/adit/mass_transfer/utils/partitions.py
+++ b/adit/mass_transfer/utils/partitions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 

--- a/scripts/csv_to_mass_transfer_filters.py
+++ b/scripts/csv_to_mass_transfer_filters.py
@@ -14,8 +14,6 @@ Usage examples:
     python scripts/csv_to_mass_transfer_filters.py filters.csv -o output.json
 """
 
-from __future__ import annotations
-
 import argparse
 import csv
 import json


### PR DESCRIPTION
Removes `from __future__ import annotations` from the four `mass_transfer` modules (the only ones that had it) for consistency — we're standardizing on *not* using PEP 563 (3.14's PEP 649 makes forward refs work natively anyway, and this avoids the runtime string-annotation semantics that interact with pydantic).

## What
- `models.py`: re-quote the forward references that relied on it — `list["FilterSpec"]` (a `TYPE_CHECKING`-only import that breaks the models↔processors cycle) and `QuerySet["MassTransferTask"]` / `QuerySet["MassTransferVolume"]` (classes defined later in the file).
- `processors.py`: re-quote `-> "FilterSpec"` (self-reference in the class body).
- `forms.py` (pydantic) and `utils/partitions.py` (dataclass): had no forward refs, so the import was redundant — just removed.

## Verification
- All four modules **import without `NameError`** (the real test for the re-quoted forward refs).
- ruff doesn't re-flag the quotes (UP037 correctly treats them as necessary).
- `cli lint` (ruff, pyright, djlint) and all 18 pre-commit hooks pass.
- The pydantic `FilterSchema` in `forms.py` has only simple field types and imports cleanly; CI tests confirm validation behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
