### PR TITLE
Fail tests on unexpected warnings and fix resource leaks

### DIFF
--- a/adit/core/utils/file_transmit.py
+++ b/adit/core/utils/file_transmit.py
@@ -201,6 +201,14 @@ class FileTransmitClient:
                 if finished:
                     break
         finally:
-            # The client reports that is well served and doesn't need any  further
-            # files by writing an eof.
-            writer.write_eof()
+            # The client reports that it is well served and doesn't need any further
+            # files by writing an eof, then closes the connection.
+            try:
+                writer.write_eof()
+            except OSError:
+                pass  # the connection may already be gone
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except OSError:
+                pass

--- a/adit/dicom_explorer/views.py
+++ b/adit/dicom_explorer/views.py
@@ -5,6 +5,7 @@ from adit_radis_shared.common.types import AuthenticatedHttpRequest
 from django.conf import settings
 from django.contrib.auth.decorators import login_required, permission_required
 from django.core.exceptions import ValidationError
+from django.db import close_old_connections
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import resolve, reverse
@@ -71,7 +72,7 @@ async def dicom_explorer_resources_view(
     try:
         future = loop.run_in_executor(
             None,
-            render_query_result,
+            _render_query_result_in_worker,
             request,
             server_id,
             patient_id,
@@ -98,6 +99,14 @@ def is_valid_id(value):
 
 def render_error(request: HttpRequest, error_message: str) -> HttpResponse:
     return render(request, "dicom_explorer/error_message.html", {"error_message": error_message})
+
+
+def _render_query_result_in_worker(*args) -> HttpResponse:
+    # Runs in an executor thread; close this thread's db connections when done.
+    try:
+        return render_query_result(*args)
+    finally:
+        close_old_connections()
 
 
 def render_query_result(

--- a/adit/selective_transfer/consumers.py
+++ b/adit/selective_transfer/consumers.py
@@ -15,6 +15,7 @@ from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from crispy_forms.utils import render_crispy_form
 from django.conf import settings
+from django.db import close_old_connections
 from django.template.loader import render_to_string
 from django.utils.translation import (
     get_supported_language_variant,
@@ -272,6 +273,8 @@ class SelectiveTransferConsumer(AsyncJsonWebsocketConsumer):
             with lock:
                 if operator in self.query_operators:
                     self.query_operators.remove(operator)
+            # Runs in a pool thread; close this thread's db connections.
+            close_old_connections()
 
         return None
 
@@ -301,42 +304,46 @@ class SelectiveTransferConsumer(AsyncJsonWebsocketConsumer):
         studies: list[ResultDataset],
         max_results_reached: bool,
     ) -> None:
-        # Rerender form to remove potential previous error messages
-        with override(getattr(self, "user_language", settings.LANGUAGE_CODE)):
-            rendered_form = render_crispy_form(form)
+        # Runs debounced in a timer thread; close this thread's db connections.
+        try:
+            # Rerender form to remove potential previous error messages
+            with override(getattr(self, "user_language", settings.LANGUAGE_CODE)):
+                rendered_form = render_crispy_form(form)
 
-            studies = sorted(
-                studies,
-                key=lambda study: datetime.combine(study.StudyDate, study.StudyTime),
-                reverse=True,
-            )
+                studies = sorted(
+                    studies,
+                    key=lambda study: datetime.combine(study.StudyDate, study.StudyTime),
+                    reverse=True,
+                )
 
-            source = cast(DicomNode, form.cleaned_data["source"])
-            server_id = source.dicomserver.pk
-            can_download = self.user.has_perm("selective_transfer.can_download_study")
+                source = cast(DicomNode, form.cleaned_data["source"])
+                server_id = source.dicomserver.pk
+                can_download = self.user.has_perm("selective_transfer.can_download_study")
 
-            pseudo_params = {
-                "pseudonym": form.cleaned_data["pseudonym"],
-                "trial_protocol_id": form.cleaned_data["trial_protocol_id"],
-                "trial_protocol_name": form.cleaned_data["trial_protocol_name"],
-            }
+                pseudo_params = {
+                    "pseudonym": form.cleaned_data["pseudonym"],
+                    "trial_protocol_id": form.cleaned_data["trial_protocol_id"],
+                    "trial_protocol_name": form.cleaned_data["trial_protocol_name"],
+                }
 
-            pseudo_params = {k: v for k, v in pseudo_params.items() if v}
-            encoded_pseudo_params = urlencode(pseudo_params)
+                pseudo_params = {k: v for k, v in pseudo_params.items() if v}
+                encoded_pseudo_params = urlencode(pseudo_params)
 
-            rendered_query_results = render_to_string(
-                "selective_transfer/_query_results.html",
-                {
-                    "query": True,
-                    "query_results": studies,
-                    "max_results_reached": max_results_reached,
-                    "server_id": server_id,
-                    "pseudo_params": encoded_pseudo_params,
-                    "can_download": can_download,
-                },
-            )
+                rendered_query_results = render_to_string(
+                    "selective_transfer/_query_results.html",
+                    {
+                        "query": True,
+                        "query_results": studies,
+                        "max_results_reached": max_results_reached,
+                        "server_id": server_id,
+                        "pseudo_params": encoded_pseudo_params,
+                        "can_download": can_download,
+                    },
+                )
 
-        async_to_sync(self.send)(rendered_form + rendered_query_results)
+            async_to_sync(self.send)(rendered_form + rendered_query_results)
+        finally:
+            close_old_connections()
 
     async def make_transfer(self, form: SelectiveTransferJobForm) -> None:
         selected_studies: str | list[str] | None = form.data.get("selected_studies")

--- a/adit/selective_transfer/consumers.py
+++ b/adit/selective_transfer/consumers.py
@@ -15,7 +15,7 @@ from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from crispy_forms.utils import render_crispy_form
 from django.conf import settings
-from django.db import close_old_connections
+from django.db import connections
 from django.template.loader import render_to_string
 from django.utils.translation import (
     get_supported_language_variant,
@@ -274,7 +274,7 @@ class SelectiveTransferConsumer(AsyncJsonWebsocketConsumer):
                 if operator in self.query_operators:
                     self.query_operators.remove(operator)
             # Runs in a pool thread; close this thread's db connections.
-            close_old_connections()
+            connections.close_all()
 
         return None
 
@@ -343,7 +343,7 @@ class SelectiveTransferConsumer(AsyncJsonWebsocketConsumer):
 
             async_to_sync(self.send)(rendered_form + rendered_query_results)
         finally:
-            close_old_connections()
+            connections.close_all()
 
     async def make_transfer(self, form: SelectiveTransferJobForm) -> None:
         selected_studies: str | list[str] | None = form.data.get("selected_studies")

--- a/adit/settings/test.py
+++ b/adit/settings/test.py
@@ -16,3 +16,7 @@ if not DATABASES["default"]["NAME"].startswith("test_"):  # noqa: F405
     DATABASES["default"]["TEST"] = {"NAME": test_database}  # noqa: F405
 
 DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda request: False}
+
+# No real backups as a side effect of tests that run the worker (the periodic
+# backup_db task would fire when a test run crosses its cron time).
+BACKUP_ENABLED = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,8 @@ log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(linen
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 markers = ["acceptance: mark a test as an acceptance test."]
 filterwarnings = [
+    # Fail on any warning not explicitly ignored below
+    "error",
     # We already fixed this, so we only need to remove this ignore with next major version of factory boy
     "ignore:.*Factory._after_postgeneration will stop saving the instance:DeprecationWarning",
     "ignore:'cgi' is deprecated:DeprecationWarning",


### PR DESCRIPTION
## Summary

- pytest now turns every warning not matching an explicit ignore into a test failure (`"error"` first in `filterwarnings`), so warnings can't silently accumulate.
- The net immediately surfaced real production resource leaks, fixed here:
  - **selective_transfer consumer**: the query pool threads and the `@debounce()` timer thread (a fresh thread per debounced response, rendering ORM-backed templates) leaked one Postgres connection each — connections are thread-local and nothing closed them.
  - **dicom_explorer**: the async view runs its ORM-backed rendering in the event loop's default executor with no connection cleanup.
  - **file_transmit client**: the `StreamWriter` was never closed after `write_eof()` — and on an already-dead connection `write_eof()` itself raises, skipping any cleanup.
- Test settings disable `backup_db` so a suite run crossing the backup cron time can't fire a real `pg_dump` (dedicated backup coverage lives in adit-radis-shared with the command mocked).

## Verification

Full suite in the dev container with warnings-as-errors: **912 passed, 3 xfailed, 0 warnings, RC=0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup for background and threaded operations, reducing the chance of stale connections or failed requests during file transfer and query handling.
  * Added safer handling when connections are already closed, making shutdown and completion more reliable.

* **Tests**
  * Tightened test warning handling so unexpected warnings now fail tests, helping catch issues earlier.
  * Disabled backup side effects in test runs to keep acceptance tests more stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->