### PR TITLE
Pass .env through to app containers via env_file

### DIFF
--- a/adit/settings/base.py
+++ b/adit/settings/base.py
@@ -47,7 +47,7 @@ SECRET_KEY = env.str("DJANGO_SECRET_KEY")
 
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS")
 
-CSRF_TRUSTED_ORIGINS = env.list("DJANGO_CSRF_TRUSTED_ORIGINS")
+CSRF_TRUSTED_ORIGINS = env.list("DJANGO_CSRF_TRUSTED_ORIGINS", default=[])
 
 _stack_name = env.str("STACK_NAME", default="")
 SESSION_COOKIE_NAME = f"sessionid_{_stack_name}" if _stack_name else "sessionid"

--- a/adit/settings/development.py
+++ b/adit/settings/development.py
@@ -7,8 +7,8 @@ ENVIRONMENT = "development"
 
 INTERNAL_IPS = env.list("DJANGO_INTERNAL_IPS")
 
-REMOTE_DEBUGGING_ENABLED = env.bool("REMOTE_DEBUGGING_ENABLED")
-REMOTE_DEBUGGING_PORT = env.int("REMOTE_DEBUGGING_PORT")
+REMOTE_DEBUGGING_ENABLED = env.bool("REMOTE_DEBUGGING_ENABLED", default=False)
+REMOTE_DEBUGGING_PORT = env.int("REMOTE_DEBUGGING_PORT", default=5678)
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
@@ -23,7 +23,7 @@ MIDDLEWARE += [  # noqa: F405
     "django_browser_reload.middleware.BrowserReloadMiddleware",
 ]
 
-if env.bool("FORCE_DEBUG_TOOLBAR"):
+if env.bool("FORCE_DEBUG_TOOLBAR", default=True):
     DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda _: True}
 
 LOGGING["loggers"]["adit"]["level"] = "DEBUG"  # noqa: F405

--- a/adit/settings/production.py
+++ b/adit/settings/production.py
@@ -16,7 +16,7 @@ STORAGES["staticfiles"] = {  # noqa: F405
     "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
 }
 
-SECURE_SSL_REDIRECT = env.bool("DJANGO_SECURE_SSL_REDIRECT")
+SECURE_SSL_REDIRECT = env.bool("DJANGO_SECURE_SSL_REDIRECT", default=True)
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_TIMEOUT = 60

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -4,26 +4,17 @@ x-app: &default-app
     - ${MOUNT_DIR:?}:/mnt
   depends_on:
     - postgres
+  env_file:
+    - .env
   environment:
-    BACKUP_CRON: ${BACKUP_CRON:-0 3 * * *}
-    BACKUP_ENABLED: ${BACKUP_ENABLED:-true}
-    CALLING_AE_TITLE: ${CALLING_AE_TITLE:?}
     DATABASE_URL: postgres://postgres:postgres@postgres.local:5432/postgres
     DBBACKUP_STORAGE_LOCATION: /backups
-    DJANGO_ADMIN_EMAIL: ${DJANGO_ADMIN_EMAIL:?}
-    DJANGO_ADMIN_FULL_NAME: ${DJANGO_ADMIN_FULL_NAME:?}
-    DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:?}
-    DJANGO_CSRF_TRUSTED_ORIGINS: ${DJANGO_CSRF_TRUSTED_ORIGINS:-}
-    DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:?}
-    DJANGO_SERVER_EMAIL: ${DJANGO_SERVER_EMAIL:?}
-    EXCLUDE_MODALITIES: ${EXCLUDE_MODALITIES:-}
     IS_DOCKER_CONTAINER: 1
     FILE_TRANSMIT_HOST: receiver.local
     FILE_TRANSMIT_PORT: 14638
-    HTTP_PROXY: ${HTTP_PROXY:-}
-    HTTPS_PROXY: ${HTTPS_PROXY:-}
+    # MOUNT_DIR from the .env file is the host path of the volume mapped to /mnt,
+    # inside the containers the mount point itself is used.
     MOUNT_DIR: /mnt
-    NO_PROXY: ${NO_PROXY:-}
     ORTHANC1_DICOM_PORT: 7501
     ORTHANC1_DICOMWEB_ROOT: dicom-web
     ORTHANC1_HOST: orthanc1.local
@@ -32,19 +23,10 @@ x-app: &default-app
     ORTHANC2_DICOMWEB_ROOT: dicom-web
     ORTHANC2_HOST: orthanc2.local
     ORTHANC2_HTTP_PORT: 6502
-    RECEIVER_AE_TITLE: ${RECEIVER_AE_TITLE:?}
-    SITE_DOMAIN: ${SITE_DOMAIN:?}
-    SITE_NAME: ${SITE_NAME:?}
     STORE_SCP_HOST: receiver.local
     STORE_SCP_PORT: 11112
-    SUPERUSER_AUTH_TOKEN: ${SUPERUSER_AUTH_TOKEN:-}
-    SUPERUSER_EMAIL: ${SUPERUSER_EMAIL:-}
-    SUPERUSER_USERNAME: ${SUPERUSER_USERNAME:-}
-    SUPERUSER_PASSWORD: ${SUPERUSER_PASSWORD:-}
-    SUPPORT_EMAIL: ${SUPPORT_EMAIL:?}
-    TIME_ZONE: ${TIME_ZONE:?}
-    TOKEN_AUTHENTICATION_SALT: ${TOKEN_AUTHENTICATION_SALT:?}
-    ANONYMIZATION_SEED: ${ANONYMIZATION_SEED:-}
+    # STACK_NAME is computed by the CLI and passed as process environment variable,
+    # it is not necessarily set in the .env file.
     STACK_NAME: ${STACK_NAME:-}
 
 services:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,11 +3,7 @@ x-app: &default-app
     target: development
   pull_policy: build
   environment:
-    DJANGO_INTERNAL_IPS: ${DJANGO_INTERNAL_IPS:?}
     DJANGO_SETTINGS_MODULE: adit.settings.development
-    FORCE_DEBUG_TOOLBAR: ${FORCE_DEBUG_TOOLBAR:-true}
-    REMOTE_DEBUGGING_ENABLED: ${REMOTE_DEBUGGING_ENABLED:-false}
-    REMOTE_DEBUGGING_PORT: ${REMOTE_DEBUGGING_PORT:-5678}
   develop:
     watch:
       - action: sync

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,11 +5,8 @@ x-app: &default-app
     - ${SSL_SERVER_CERT_FILE:?}:/etc/web/ssl/cert.pem
     - ${SSL_SERVER_KEY_FILE:?}:/etc/web/ssl/key.pem
   environment:
-    DJANGO_EMAIL_URL: ${DJANGO_EMAIL_URL:?}
-    DJANGO_SECURE_SSL_REDIRECT: ${DJANGO_SECURE_SSL_REDIRECT:-true}
     DJANGO_SETTINGS_MODULE: adit.settings.production
     DJANGO_STATIC_ROOT: /var/www/web/static/
-    POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?}
 
 x-deploy: &deploy
   replicas: 1

--- a/example.env
+++ b/example.env
@@ -1,3 +1,6 @@
+# IMPORTANT: Values must not be wrapped in quotes. This file is passed through to the
+# containers as is, and 'docker stack deploy' treats quotes as part of the value.
+
 # The environment setting.
 # Use 'development' for local development, and 'production' in production.
 ENVIRONMENT=development
@@ -29,10 +32,10 @@ REMOTE_DEBUGGING_PORT=5678
 
 # The Django secret key used for cryptographic signing.
 # IMPORTANT: Use a unique and secure key in production!
-DJANGO_SECRET_KEY="your_django_secret_key_here"
+DJANGO_SECRET_KEY=your_django_secret_key_here
 
 # The Postgres database password (only used in production).
-POSTGRES_PASSWORD="your_postgres_password_here"
+POSTGRES_PASSWORD=your_postgres_password_here
 
 # Miscellaneous Django security settings.
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
@@ -44,42 +47,42 @@ DJANGO_SECURE_SSL_REDIRECT=true
 
 # The salt that is used for hashing tokens in the token authentication app.
 # Cave, changing the salt after some tokens were already generated makes them all invalid!
-TOKEN_AUTHENTICATION_SALT="your_token_authentication_salt_here"
+TOKEN_AUTHENTICATION_SALT=your_token_authentication_salt_here
 
 # Email configuration.
 # The email address that is used for sending emails to the users and critical errors
 # to the admins. The smtp server is only used in production. In development the emails
 # are just logged to the console.
-DJANGO_SERVER_EMAIL="server@example-project.example"
-DJANGO_EMAIL_URL="smtp://localhost:25"
+DJANGO_SERVER_EMAIL=server@example-project.example
+DJANGO_EMAIL_URL=smtp://localhost:25
 
 # The Django server admins that will receive critical error notifications.
 # Also used by django-registration-redux to send account approval emails to.
-DJANGO_ADMIN_EMAIL="admin@adit.example"
-DJANGO_ADMIN_FULL_NAME="ADIT Admin"
+DJANGO_ADMIN_EMAIL=admin@adit.example
+DJANGO_ADMIN_FULL_NAME=ADIT Admin
 
 # A support Email address that is presented to the users where they can get support.
-SUPPORT_EMAIL="support@adit.example"
+SUPPORT_EMAIL=support@adit.example
 
 # A superuser that will have access to the Django admin interface.
 # Optionally with a provided auth token for the API.
-SUPERUSER_USERNAME="superuser"
-SUPERUSER_EMAIL="superuser@adit.example"
-SUPERUSER_PASSWORD="your_superuser_password_here"
-SUPERUSER_AUTH_TOKEN="your_superuser_auth_token_here"
+SUPERUSER_USERNAME=superuser
+SUPERUSER_EMAIL=superuser@adit.example
+SUPERUSER_PASSWORD=your_superuser_password_here
+SUPERUSER_AUTH_TOKEN=your_superuser_auth_token_here
 
 # Location of the backup folder.
-BACKUP_DIR="./.docker-data/backups"
+BACKUP_DIR=./.docker-data/backups
 
 # Enable the daily database backup periodic task.
 # Set to "false" to no-op the shared backup_db task (e.g. in test environments).
 BACKUP_ENABLED=true
 
 # Cron schedule for the shared backup_db periodic task.
-BACKUP_CRON="0 3 * * *"
+BACKUP_CRON=0 3 * * *
 
 # Site information that is synced to the database and used by the sites framework.
-SITE_NAME="ADIT"
+SITE_NAME=ADIT
 SITE_DOMAIN=localhost
 
 # Settings for SSL encryption (only used in production).
@@ -90,23 +93,23 @@ SITE_DOMAIN=localhost
 # certificate chain using 'uv run cli generate-certificate-chain'.
 SSL_HOSTNAME=localhost
 SSL_IP_ADDRESSES=127.0.0.1
-SSL_SERVER_CERT_FILE="./cert.pem"
-SSL_SERVER_KEY_FILE="./key.pem"
-SSL_SERVER_CHAIN_FILE="./chain.pem"
+SSL_SERVER_CERT_FILE=./cert.pem
+SSL_SERVER_KEY_FILE=./key.pem
+SSL_SERVER_CHAIN_FILE=./chain.pem
 
 # The timezone used by the server.
-TIME_ZONE="Europe/Berlin"
+TIME_ZONE=Europe/Berlin
 
 # The calling AE title of ADIT.
-CALLING_AE_TITLE="ADIT1DEV"
+CALLING_AE_TITLE=ADIT1DEV
 
 # The AE title where the receiver is listening for incoming files.
-RECEIVER_AE_TITLE="ADIT1DEV"
+RECEIVER_AE_TITLE=ADIT1DEV
 
 # A comma separated list of DICOM modalities that should be excluded when
 # a study is transferred or downloaded pseudonymized using the web interface.
 # This does not affect downloads using the ADIT client.
-EXCLUDE_MODALITIES="PR,SR"
+EXCLUDE_MODALITIES=PR,SR
 
 # Replicas of the services that can be scaled (production).
 WEB_REPLICAS=5
@@ -114,10 +117,10 @@ DICOM_WORKER_REPLICAS=3
 MASS_TRANSFER_WORKER_REPLICAS=5
 
 # The directory where download folders are mounted.
-MOUNT_DIR="./.docker-data/mount"
+MOUNT_DIR=./.docker-data/mount
 
 # A seed that is used for anonymizing DICOM files on the client.
-ANONYMIZATION_SEED="123456789"
+ANONYMIZATION_SEED=123456789
 
 # Docker swarm mode does not respect the Docker Proxy client configuration
 # (see https://docs.docker.com/network/proxy/#configure-the-docker-client),


### PR DESCRIPTION
## Summary

Counterpart to openradx/adit-radis-shared#216.

- Add `env_file: .env` to the app services in `docker-compose.base.yml` and remove all `environment:` entries that just re-declared variables from the `.env` file. Hardcoded container values stay (`DATABASE_URL`, `DJANGO_SETTINGS_MODULE`, `MOUNT_DIR: /mnt`, orthanc/receiver hosts and ports, `IS_DOCKER_CONTAINER`, ...), as does `STACK_NAME`, which the CLI injects as a process environment variable rather than via `.env`. Non-app services (postgres, orthanc) keep their explicit environment — dev postgres must not pick up the production `POSTGRES_PASSWORD` from the `.env` file.
- Move required/optional semantics into the Django settings: optional variables (previously `${VAR:-default}`) now have defaults there (`DJANGO_CSRF_TRUSTED_ORIGINS`, `FORCE_DEBUG_TOOLBAR`, `REMOTE_DEBUGGING_ENABLED`, `REMOTE_DEBUGGING_PORT`, `DJANGO_SECURE_SSL_REDIRECT`, `TIME_ZONE`), required ones (previously `${VAR:?}`) have no default so `environs` raises at startup when they are missing.
- Unquote all values in `example.env`: `docker compose` strips surrounding quotes from env file values, but `docker stack deploy` passes them to the containers verbatim. The shared CLI (see the shared PR) fails early on quoted values during `stack-deploy`.

## Test plan

- [x] Effective per-service container environment compared before/after via `docker compose config` (dev) and `docker stack config` (prod): identical values for all previously declared variables.
- [x] Dev stack recreated with the new config; all containers healthy, env spot-checked in the web container.
- [x] `ruff` and `pyright` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)