### PR TITLE
Add compose project label to swarm-deployed containers

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,10 @@
 x-app: &default-app
   image: ${ADIT_IMAGE:-ghcr.io/openradx/adit:latest}
+  # docker stack deploy doesn't set the compose project label on containers,
+  # so container tools (e.g. the VS Code Containers view) can't group them by
+  # stack. STACK_NAME is injected by the cli stack-deploy command.
+  labels:
+    com.docker.compose.project: ${STACK_NAME:-adit_prod}
   volumes:
     - web_data:/var/www/web
     - ${SSL_SERVER_CERT_FILE:?}:/etc/web/ssl/cert.pem
@@ -95,16 +100,22 @@ services:
       <<: *deploy
 
   postgres:
+    labels:
+      com.docker.compose.project: ${STACK_NAME:-adit_prod}
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?}
     deploy:
       <<: *deploy
 
   orthanc1:
+    labels:
+      com.docker.compose.project: ${STACK_NAME:-adit_prod}
     deploy:
       <<: *deploy
 
   orthanc2:
+    labels:
+      com.docker.compose.project: ${STACK_NAME:-adit_prod}
     deploy:
       <<: *deploy
 


### PR DESCRIPTION
## Problem

`docker stack deploy` labels containers with `com.docker.stack.namespace` but not `com.docker.compose.project`. Container tooling that groups by compose project — most visibly the VS Code Containers view — therefore lists all swarm stack containers under **Individual Containers** instead of grouping them per stack.

## Solution

Set `com.docker.compose.project` explicitly on all prod services, using the `STACK_NAME` that `cli stack-deploy` already injects into the compose environment (with the stack's default name as fallback). Each deployed stack (e.g. `adit_prod`, `adit_staging`) then appears as its own group.

Verified with `docker compose config`: all nine services render the label. Swarm accepts these labels alongside its own — containers group correctly in the VS Code Containers view.

Same change as openradx/radis#251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)