### PR TITLE
Match exclude filters case-insensitively in mass transfer

### DIFF
--- a/adit/mass_transfer/forms.py
+++ b/adit/mass_transfer/forms.py
@@ -106,7 +106,15 @@ class MassTransferJobForm(forms.ModelForm):
             "series also matching an exclude filter is removed. "
             "At least one include filter is required. "
             "apply_institution_on_study is ignored on exclude filters "
-            "(institution is matched at series level)."
+            "(institution is matched at series level). "
+            "String criteria support DICOM wildcards (* and ?) and are "
+            "matched against the whole value. On include filters they are "
+            "matched CASE-SENSITIVELY, consistent with how a "
+            "standard-conformant PACS matches non-PN fields in C-FIND. "
+            "Exclude filters never reach the PACS — they are applied "
+            "client-side to the retrieved results — and are matched "
+            "CASE-INSENSITIVELY, so e.g. '*cor*' also removes series "
+            "described 'COR' or 'Cor'."
         ),
     )
 

--- a/adit/mass_transfer/processors.py
+++ b/adit/mass_transfer/processors.py
@@ -97,14 +97,16 @@ class DiscoveredSeries:
     patient_birth_date: date | None = None
 
 
-def _dicom_match(pattern: str, value: str | None) -> bool:
+def _dicom_match(pattern: str, value: str | None, case_insensitive: bool = False) -> bool:
     # Callers only pass non-PN fields (institution_name, study_description,
-    # series_description); those are compared case-sensitively.
+    # series_description). Include filters compare case-sensitively to stay
+    # consistent with PACS-side matching of non-PN fields; exclude filters are
+    # applied client-side only and pass case_insensitive=True.
     if not pattern:
         return True
     if value is None:
         return False
-    regex = convert_to_python_regex(pattern)
+    regex = convert_to_python_regex(pattern, case_insensitive=case_insensitive)
     return bool(regex.fullmatch(str(value)))
 
 
@@ -250,15 +252,26 @@ def _series_matches_filter(
     filter.  The strict default is used by include filters so that an
     unknown age also fails inclusion — in both directions, a series whose
     age can't be determined is dropped.
+
+    String criteria on include filters are matched case-sensitively, in line
+    with PACS-side matching of non-PN fields.  Exclude filters are applied
+    client-side only (they never reach the PACS), so they match
+    case-insensitively — scanner naming conventions vary in capitalization
+    (COR/Cor/cor) and an exclude should catch all variants.
     """
+    case_insensitive = mf.mode == "exclude"
     if mf.modality and mf.modality != series.modality:
         return False
     if check_institution and mf.institution_name:
-        if not _dicom_match(mf.institution_name, series.institution_name):
+        if not _dicom_match(mf.institution_name, series.institution_name, case_insensitive):
             return False
-    if mf.study_description and not _dicom_match(mf.study_description, series.study_description):
+    if mf.study_description and not _dicom_match(
+        mf.study_description, series.study_description, case_insensitive
+    ):
         return False
-    if mf.series_description and not _dicom_match(mf.series_description, series.series_description):
+    if mf.series_description and not _dicom_match(
+        mf.series_description, series.series_description, case_insensitive
+    ):
         return False
     if mf.series_number is not None:
         if series.series_number is None or mf.series_number != series.series_number:

--- a/adit/mass_transfer/tests/test_processor.py
+++ b/adit/mass_transfer/tests/test_processor.py
@@ -521,6 +521,34 @@ def test_discover_series_exclude_removes_matching_series(mocker: MockerFixture):
     assert series_uids == {"1.2.3.601"}
 
 
+def test_discover_series_exclude_is_case_insensitive(mocker: MockerFixture):
+    """Exclude filters are matched case-insensitively: scanner naming varies
+    in capitalization (COR, Cor, cor), and excludes never touch the PACS."""
+    processor = _make_processor(mocker)
+    processor.mass_task.partition_start = datetime(2024, 1, 1, 0, 0)
+    processor.mass_task.partition_end = datetime(2024, 1, 1, 23, 59, 59)
+
+    operator = mocker.create_autospec(DicomOperator)
+    operator.server = mocker.MagicMock(max_search_results=200)
+
+    study = _make_study("1.2.3.100")
+    study.dataset.ModalitiesInStudy = ["CT"]
+    operator.find_studies.return_value = [study]
+
+    axial = _make_series_result("1.2.3.601", series_description="Axial T1")
+    topogram = _make_series_result("1.2.3.602", series_description="TOPOGRAM 1.0 T20s")
+    operator.find_series.return_value = [axial, topogram]
+
+    filters = [
+        _make_filter(modality="CT"),
+        FilterSpec(mode="exclude", series_description="*topo*"),
+    ]
+    result = processor._discover_series(operator, filters)
+
+    series_uids = {s.series_instance_uid for s in result}
+    assert series_uids == {"1.2.3.601"}
+
+
 def test_discover_series_exclude_does_not_trigger_find(mocker: MockerFixture):
     """Exclude filters must not issue their own C-FIND calls."""
     processor = _make_processor(mocker)
@@ -1667,6 +1695,24 @@ def test_series_matches_filter_series_number_exact():
 def test_series_matches_filter_series_number_unknown_fails_match():
     series = _make_discovered(series_number=None)
     assert _series_matches_filter(series, FilterSpec(series_number=1)) is False
+
+
+def test_series_matches_filter_exclude_series_description_case_insensitive():
+    series = _make_discovered(series_description="COR 2mm")
+    mf = FilterSpec(mode="exclude", series_description="*cor*")
+    assert _series_matches_filter(series, mf, age_permissive=True) is True
+
+
+def test_series_matches_filter_exclude_institution_case_insensitive():
+    series = _make_discovered()  # institution_name "Radiology"
+    mf = FilterSpec(mode="exclude", institution_name="RADIOLOGY")
+    assert _series_matches_filter(series, mf, age_permissive=True) is True
+
+
+def test_series_matches_filter_include_series_description_stays_case_sensitive():
+    series = _make_discovered(series_description="COR 2mm")
+    mf = FilterSpec(series_description="*cor*")
+    assert _series_matches_filter(series, mf) is False
 
 
 def test_series_matches_filter_institution_checked_by_default():


### PR DESCRIPTION
## Motivation

Since #355, `_dicom_match` compares all non-PN string criteria case-sensitively. For **include** filters this is right: `StudyDescription`, `ModalitiesInStudy` etc. are sent in the C-FIND, PS3.4 specifies case-sensitive matching for non-PN fields, and the client-side re-check should mirror what the PACS does.

**Exclude** filters are a different situation: they never reach the PACS — they are applied purely client-side to the retrieved series list (`_discover_series`). They are typically blocklists for localizer/reformat/scout series (`*cor*`, `*sag*`, `*topo*`, …) whose capitalization varies freely between scanners and sites (`COR`, `Cor`, `cor`, `Topogramm`). Matching them case-sensitively makes such series silently slip through the blocklist.

Real-world data point: on one of our production mass transfer jobs (~285M images), case-sensitive excludes would have admitted ~36M images (~11% of the selection) in series like `COR` and `Topogramm` that the lowercase exclude patterns were meant to drop.

## Changes

- `_dicom_match` gains a `case_insensitive` flag (forwarded to `convert_to_python_regex`, which already supported it).
- `_series_matches_filter` matches institution_name / study_description / series_description case-insensitively **when `mf.mode == "exclude"`**; include filters remain case-sensitive whole-value DICOM wildcard matches.
- The `filters_json` form help text now documents both behaviors (case-sensitive includes consistent with PACS-side C-FIND matching; case-insensitive client-side excludes).

## Tests

TDD: the three new tests (exclude series_description, exclude institution_name, `_discover_series` end-to-end) were written first and failed on the old behavior; a fourth guard test pins include matching as case-sensitive. `ruff`, `ruff format` and `pyright` are clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded filter help text with wildcard syntax, case-sensitivity rules, client-side exclusion behavior, and examples.

- **Bug Fixes**
  - Exclude filters now match institution, study, and series descriptions without regard to letter case.
  - Include filters retain case-sensitive matching.
  - Exclude filtering avoids unnecessary PACS queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->