### PR TITLE
Bump adit-radis-shared to 0.26.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.0.0"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.25.0",
+    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.26.0",
     "adrf>=0.1.9",
     "aiofiles>=24.1.0",
     "asyncinotify>=4.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.25.0" },
+    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.26.0" },
     { name = "adrf", specifier = ">=0.1.9" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "asyncinotify", specifier = ">=4.2.0" },
@@ -221,7 +221,7 @@ requires-dist = [
 [[package]]
 name = "adit-radis-shared"
 version = "0.0.0"
-source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.25.0#793b48e440678968e8a933049113045c2f6a126f" }
+source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.26.0#d46611ff80d4fece27aaa946a994e18d9c69156f" }
 dependencies = [
     { name = "channels" },
     { name = "crispy-bootstrap5" },


### PR DESCRIPTION
Picks up [0.26.0](https://github.com/openradx/adit-radis-shared/releases/tag/0.26.0).

`compose-down` now passes `--remove-orphans` (openradx/adit-radis-shared#231), so a container this project no longer defines is removed rather than left running:

```
$ SIMULATE=true uv run cli compose-down
Simulating: docker compose ... -p adit_dev down --remove-orphans
```

Also included: a configurable Postgres startup wait, `.env` passthrough to the app containers via `env_file`, and a cryptography security update.

Verified against this release: 859 passed, 66 deselected, 3 xfailed; lint clean. Worth noting the release also makes tests fail on unexpected warnings, which is why the suite was run rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXPHZrTzdGdHmNv6ZTEDJN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the shared package dependency to version 0.26.0 for improved compatibility and access to the latest shared functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->