### PR TITLE
Bump adit-radis-shared to 0.27.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.0.0"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.26.0",
+    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.27.0",
     "adrf>=0.1.9",
     "aiofiles>=24.1.0",
     "asyncinotify>=4.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.26.0" },
+    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.27.0" },
     { name = "adrf", specifier = ">=0.1.9" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "asyncinotify", specifier = ">=4.2.0" },
@@ -221,7 +221,7 @@ requires-dist = [
 [[package]]
 name = "adit-radis-shared"
 version = "0.0.0"
-source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.26.0#d46611ff80d4fece27aaa946a994e18d9c69156f" }
+source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.27.0#b081ea48fc250b0a6ad9a5c8e852dd6ddeeaf2b0" }
 dependencies = [
     { name = "channels" },
     { name = "crispy-bootstrap5" },


### PR DESCRIPTION
Picks up [0.27.0](https://github.com/openradx/adit-radis-shared/releases/tag/0.27.0), where the CLI passes arguments through to the underlying commands rather than deciding options itself (openradx/adit-radis-shared#232).

Two behaviour changes reach ADIT:

- `compose-down` no longer adds `--remove-orphans` on its own — pass it when you want containers the compose files no longer define to be removed
- `stack-deploy` accepts arguments, so `-- --prune` removes services the deployment no longer declares

```
$ SIMULATE=true uv run cli compose-down
Simulating: docker compose ... down

$ SIMULATE=true uv run cli compose-down -- --remove-orphans
Simulating: docker compose ... down --remove-orphans
```

Verified against this release: 859 passed, 66 deselected, 3 xfailed; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXPHZrTzdGdHmNv6ZTEDJN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->