### PR TITLE
Let Renovate refresh uv.lock when the shared pin moves

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,18 +8,6 @@
     "schedule": ["before 5am on Monday"]
   },
   "automerge": true,
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Track the adit-radis-shared git tag pinned in pyproject.toml (pep621 cannot resolve direct git URLs).",
-      "managerFilePatterns": ["/(^|/)pyproject\\.toml$/"],
-      "matchStrings": [
-        "adit-radis-shared\\s*@\\s*git\\+https://github\\.com/openradx/adit-radis-shared\\.git@(?<currentValue>[^\"'\\s]+)"
-      ],
-      "depNameTemplate": "openradx/adit-radis-shared",
-      "datasourceTemplate": "github-tags"
-    }
-  ],
   "packageRules": [
     {
       "matchManagers": ["docker-compose"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.0.0"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.27.0",
+    "adit-radis-shared",
     "adrf>=0.1.9",
     "aiofiles>=24.1.0",
     "asyncinotify>=4.2.0",
@@ -103,6 +103,7 @@ constraint-dependencies = ["autobahn<25.11.1"]
 
 [tool.uv.sources]
 adit-client = { path = "./adit-client", editable = true }
+adit-radis-shared = { git = "https://github.com/openradx/adit-radis-shared.git", tag = "0.27.0" }
 
 [tool.pyright]
 ignore = ["**/migrations", "**/*.ipynb"]

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.27.0" },
+    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?tag=0.27.0" },
     { name = "adrf", specifier = ">=0.1.9" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "asyncinotify", specifier = ">=4.2.0" },
@@ -221,7 +221,7 @@ requires-dist = [
 [[package]]
 name = "adit-radis-shared"
 version = "0.0.0"
-source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.27.0#b081ea48fc250b0a6ad9a5c8e852dd6ddeeaf2b0" }
+source = { git = "https://github.com/openradx/adit-radis-shared.git?tag=0.27.0#b081ea48fc250b0a6ad9a5c8e852dd6ddeeaf2b0" }
 dependencies = [
     { name = "channels" },
     { name = "crispy-bootstrap5" },


### PR DESCRIPTION
Follow-up to #394 / openradx/radis#271, which added a `custom.regex` manager so Renovate
could see the `adit-radis-shared` git pin. It can see it, but it cannot relock it.

## The problem

`custom.regex` has no artifact-update hook. Renovate's pep621 manager delegates lockfile
refresh to the underlying CLI (`uv` or `pdm`); a regex manager never enters that path, so a
Renovate bump would edit `pyproject.toml` and leave `uv.lock` pinned to the old commit.

Nothing in the pipeline would have caught it:

| Guard | Result |
|---|---|
| `uv run cli lint` (what CI runs) | ruff, pyright, djlint — does not look at the lock |
| `uv lock --check` | catches it, but only runs as a **pre-commit hook** — bot commits never run it |
| `uv sync --frozen` (Docker build) | installs from the lock **without** comparing to `pyproject.toml` |

Verified by simulating the bump — `pyproject.toml` at one tag, `uv.lock` at another:

```
$ uv lock --check
error: The lockfile at `uv.lock` needs to be updated, but `--check` was provided.
exit 1

$ uv export --frozen   # what the Docker build effectively does
...@b081ea48fc250b0a6ad9a5c8e852dd6ddeeaf2b0     <- the OLD tag's commit
exit 0                                           <- no error
```

With `"automerge": true`, the upgrade PR would go green while still building and testing the
**old** version, then merge itself — leaving `pyproject.toml` claiming one version while the
lock and the runtime are on another. The next person to commit trips the lock hook on a
failure unrelated to their change.

A silently ineffective upgrade is worse than a red build.

## The fix

Declare the dependency in `[tool.uv.sources]` so the native pep621 manager owns it:

```toml
dependencies = ["adit-radis-shared", ...]

[tool.uv.sources]
adit-radis-shared = { git = "https://github.com/openradx/adit-radis-shared.git", tag = "0.27.0" }
```

Tracking is unchanged. Renovate's uv processor handles git sources directly, and for a `tag`
it sets exactly what the custom manager set by hand:

```js
dep.datasource   = GithubTagsDatasource.id;   // github-tags
dep.packageName  = full_name;                 // openradx/adit-radis-shared
dep.currentValue = tag;
dep.skipReason   = void 0;
```

The difference is that it now arrives via pep621, which runs `uv lock` as an artifact update.
The `customManagers` block is deleted.

## Why not `postUpgradeTasks`

Suggested by a reviewer, but it needs `allowedPostUpgradeCommands` in the **self-hosted admin**
config. These repos use the Mend-hosted App (PRs from `app/renovate`, no self-hosted runner),
which cannot grant it.

## Verification

- Resolves to the **same commit** `b081ea48` — `uv.lock` only swaps `rev=` for `tag=` (2 lines)
- Same package count; `uv lock --check` exits 0; the `uv-lock` pre-commit hook passes
- `renovate-config-validator`: `Config validated successfully`
- Package still imports under `uv run --frozen`

Note `[tool.uv.sources]` is uv-specific — pip would ignore it. Harmless here: everything
installs through `uv sync`, and the app itself is not published to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXPHZrTzdGdHmNv6ZTEDJN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration for `adit-radis-shared` to use the specified 0.27.0 source.
  * Simplified automated dependency update settings while preserving existing package rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->