### PR TITLE
Write down the comment conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,15 @@ Key variables in `.env` (see `example.env`):
 - **Line Length**: 100 characters (Ruff), 120 for templates (djlint)
 - **Type Checking**: pyright in basic mode (migrations excluded)
 - **Linting**: Ruff with E, F, I, DJ rules
+- **Comments**: write one only where the code cannot speak for itself — an invariant, a
+  constraint that is not visible locally, or a decision a future reader would otherwise
+  undo. Explain *why*, never restate *what*. A comment earns its place if removing it
+  would let someone reintroduce a bug; if it only describes the line below it, delete it.
+- **Comments describe the code as it is now**, never how it used to be or why it changed.
+  No "previously we used X", no "changed after review", no narrating the fix or the
+  discussion that produced it. That belongs in the commit message, where it stays attached
+  to the change instead of ageing in the source. The same goes for docstrings: they tell a
+  caller how to use the thing, not what it replaced.
 
 ### Assertions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,15 +152,9 @@ Key variables in `.env` (see `example.env`):
 - **Line Length**: 100 characters (Ruff), 120 for templates (djlint)
 - **Type Checking**: pyright in basic mode (migrations excluded)
 - **Linting**: Ruff with E, F, I, DJ rules
-- **Comments**: write one only where the code cannot speak for itself — an invariant, a
-  constraint that is not visible locally, or a decision a future reader would otherwise
-  undo. Explain *why*, never restate *what*. A comment earns its place if removing it
-  would let someone reintroduce a bug; if it only describes the line below it, delete it.
-- **Comments describe the code as it is now**, never how it used to be or why it changed.
-  No "previously we used X", no "changed after review", no narrating the fix or the
-  discussion that produced it. That belongs in the commit message, where it stays attached
-  to the change instead of ageing in the source. The same goes for docstrings: they tell a
-  caller how to use the thing, not what it replaced.
+- **Comments**: only where the code cannot speak for itself; explain *why*, not *what*
+- **No history in comments**: describe the code as it is, not how it changed — that
+  belongs in the commit message (docstrings too)
 
 ### Assertions
 


### PR DESCRIPTION
## Summary

Adds two comment conventions to `AGENTS.md` under Code Standards. Neither was written down anywhere — the file had no guidance on comments at all.

```markdown
- **Comments**: write one only where the code cannot speak for itself — an invariant, a
  constraint that is not visible locally, or a decision a future reader would otherwise
  undo. Explain *why*, never restate *what*. A comment earns its place if removing it
  would let someone reintroduce a bug; if it only describes the line below it, delete it.
- **Comments describe the code as it is now**, never how it used to be or why it changed.
  No "previously we used X", no "changed after review", no narrating the fix or the
  discussion that produced it. That belongs in the commit message, where it stays attached
  to the change instead of ageing in the source. The same goes for docstrings: they tell a
  caller how to use the thing, not what it replaced.
```

## Why

The second rule is the one with teeth. A comment describing a diff is meaningless to someone reading the file later — they never saw the previous version and cannot act on the information. The commit message is where that belongs, because it stays anchored to the change and `git log -L` retrieves it on demand.

A useful test falls out of it: **if a comment would be false or pointless in a fresh checkout with no history, it is in the wrong place.** "Do not swap this for `Greatest`, because a foreign config's `ts_rank` is not reliably ~0" passes — it describes the code as it stands and stops a future mistake. "Trimmed after review" fails.

The first rule exists because review-driven changes accumulate one justification per round and nobody ever removes them, since each was individually earned. What is left narrates the review rather than the code.

## Scope

Documentation only — no code, no behaviour change. `CLAUDE.md` and `GEMINI.md` are symlinks to `AGENTS.md`, so editing the one file covers all three.

The same change is opened against the sibling repositories so the convention is consistent across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded code standards guidance for comments and docstrings.
  * Clarified that documentation should explain non-obvious rationale, describe current behavior, and avoid historical change narratives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->