### PR TITLE
Drop empty components from multi-valued PN elements before pseudonymization

### DIFF
--- a/adit/core/tests/utils/test_pseudonymizer.py
+++ b/adit/core/tests/utils/test_pseudonymizer.py
@@ -178,3 +178,37 @@ class TestComputePseudonym:
         """Pseudonyms must not change across code updates (breaks cross-transfer linking)."""
         assert compute_pseudonym("my-salt", "PAT1", 12) == "81T9LZGKTAM3"
         assert compute_pseudonym("my-salt", "PAT1", 14) == "81T9LZGKTAM3UV"
+
+
+class TestPseudonymizePersonNameEdgeCases:
+    """dicognito 0.19.0 crashes on falsy (empty) PersonName components inside
+    multi-valued PN elements (e.g. OtherPatientNames "Doe^John\\"), which aborted
+    C-GET transfers in production. The pseudonymizer must tolerate these values."""
+
+    def test_empty_component_in_multivalued_person_name(self, pseudonymizer: Pseudonymizer):
+        ds = create_base_dataset()
+        ds.OtherPatientNames = ["Doe^John", ""]
+
+        pseudonymizer.pseudonymize(ds, "PSEUDO")
+
+        assert "Doe^John" not in [str(n) for n in ds.OtherPatientNames]
+
+    def test_trailing_backslash_person_name(self, pseudonymizer: Pseudonymizer):
+        ds = create_base_dataset()
+        ds.OtherPatientNames = "Doe^John\\"
+
+        pseudonymizer.pseudonymize(ds, "PSEUDO")
+
+        assert "Doe^John" not in str(ds.OtherPatientNames)
+
+    def test_empty_person_name_in_sequence_item(self, pseudonymizer: Pseudonymizer):
+        from pydicom.sequence import Sequence
+
+        ds = create_base_dataset()
+        item = Dataset()
+        item.PersonName = ["Doe^John", ""]
+        ds.OtherPatientIDsSequence = Sequence([item])
+
+        pseudonymizer.pseudonymize(ds, "PSEUDO")
+
+        assert "Doe^John" not in [str(n) for n in ds.OtherPatientIDsSequence[0].PersonName]

--- a/adit/core/utils/pseudonymizer.py
+++ b/adit/core/utils/pseudonymizer.py
@@ -4,7 +4,8 @@ import string
 from dicognito.anonymizer import Anonymizer
 from dicognito.value_keeper import ValueKeeper
 from django.conf import settings
-from pydicom import Dataset
+from pydicom import DataElement, Dataset
+from pydicom.multival import MultiValue
 
 _PSEUDONYM_ALPHABET = string.ascii_uppercase + string.digits  # A-Z0-9
 
@@ -67,6 +68,22 @@ class Pseudonymizer:
         if not pseudonym:
             raise ValueError("A valid pseudonym must be provided for pseudonymization.")
 
+        ds.walk(_drop_empty_person_name_components)
         self.anonymizer.anonymize(ds)
         ds.PatientID = pseudonym
         ds.PatientName = pseudonym
+
+
+def _drop_empty_person_name_components(_: Dataset, element: DataElement) -> None:
+    """Remove empty components from multi-valued PN elements.
+
+    dicognito (<= 0.19.0) only coerces truthy PersonName values to ``str`` before
+    hashing them, so an empty component inside a multi-valued PN element (e.g.
+    OtherPatientNames ``"Doe^John\\"``) raises ``TypeError`` and aborts the
+    transfer of the whole series. Empty components carry no information, so we
+    drop them before anonymization.
+    """
+    if element.VR != "PN" or not isinstance(element.value, MultiValue):
+        return
+    names = [str(name) for name in element.value if str(name)]
+    element.value = names if len(names) > 1 else (names[0] if names else "")


### PR DESCRIPTION
## Summary
- dicognito (<= 0.19.0, latest) only coerces *truthy* PersonName values to `str` before hashing. An empty component inside a multi-valued PN element (e.g. `OtherPatientNames = "Doe^John\"`) raises `TypeError: With tag (0010,1001) got exception: can only concatenate str (not "PersonName") to str`.
- In a mass transfer this happens inside the C-GET store handler: the C-STORE sub-operation is rejected, the association derails, the fetch times out (`Connection timed out, was aborted or received invalid response.`) and the task fails identically on every retry. Seen in production (mass transfer job 1, tasks 4155/4157, one patient with such an OtherPatientNames value).
- Fix: `Pseudonymizer.pseudonymize()` now walks the dataset (incl. sequence items) and drops empty components from multi-valued PN elements before calling dicognito. Empty components carry no information.

## Test plan
- [x] New tests in `adit/core/tests/utils/test_pseudonymizer.py` reproduce the crash (`["Doe^John", ""]`, `"Doe^John\"`, and the same inside a sequence item) and pass with the fix
- [x] `adit/core/tests/utils` green, ruff + pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pseudonymization for person names with empty components, trailing separators, or empty names in sequences.
  * Prevented anonymization failures while continuing to remove original identifying names.

* **Tests**
  * Added coverage for edge cases involving malformed or incomplete person-name values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->