### PR TITLE
Make mass transfer discovery resilient to non-conformant StudyDate/StudyTime

### DIFF
--- a/adit/mass_transfer/processors.py
+++ b/adit/mass_transfer/processors.py
@@ -126,7 +126,15 @@ def _parse_int(value: object, default: int | None = None) -> int | None:
 
 def _study_datetime(study: ResultDataset) -> datetime:
     study_date = study.StudyDate
-    study_time = study.StudyTime
+    try:
+        study_time = study.StudyTime
+    except ValueError:
+        # Some PACS return non-conformant times (e.g. "1113.672"); the time is
+        # only cosmetic (folder naming), so fall back to midnight.
+        logger.warning(
+            "Invalid StudyTime in study %s, falling back to midnight.", study.StudyInstanceUID
+        )
+        study_time = None
     if study_time is None:
         study_time = datetime.min.time()
     return datetime.combine(study_date, study_time)
@@ -310,6 +318,7 @@ class MassTransferTaskProcessor(DicomTaskProcessor):
         assert isinstance(dicom_task, MassTransferTask)
         super().__init__(dicom_task)
         self.mass_task = dicom_task
+        self._discovery_skips: list[str] = []
 
     def process(self):
         if self.is_suspended():
@@ -788,6 +797,8 @@ class MassTransferTaskProcessor(DicomTaskProcessor):
         failed_reasons: dict[str, int],
     ) -> dict:
         """Build the final status dict returned to the task processor."""
+        discovery_skips = getattr(self, "_discovery_skips", [])
+
         log_lines = [
             f"Partition {self.mass_task.partition_key}",
             f"Studies found: {study_count}",
@@ -802,10 +813,21 @@ class MassTransferTaskProcessor(DicomTaskProcessor):
             log_lines.append("Failure reasons:")
             for reason, count in failed_reasons.items():
                 log_lines.append(f"  {count}x {reason}")
+        if discovery_skips:
+            log_lines.append("Studies skipped due to invalid DICOM metadata:")
+            for entry in discovery_skips:
+                log_lines.append(f"  {entry}")
 
         if total_volumes == 0:
-            status = MassTransferTask.Status.SUCCESS
-            message = "No series found for this partition."
+            if discovery_skips:
+                status = MassTransferTask.Status.WARNING
+                message = (
+                    f"No series transferred; {len(discovery_skips)} studies skipped "
+                    "due to invalid DICOM metadata."
+                )
+            else:
+                status = MassTransferTask.Status.SUCCESS
+                message = "No series found for this partition."
         elif total_failed and not total_processed:
             status = MassTransferTask.Status.FAILURE
             message = f"All {total_failed} series failed during mass transfer."
@@ -818,9 +840,13 @@ class MassTransferTaskProcessor(DicomTaskProcessor):
                 parts.append(f"{total_skipped} skipped")
 
             status = (
-                MassTransferTask.Status.WARNING if total_failed else MassTransferTask.Status.SUCCESS
+                MassTransferTask.Status.WARNING
+                if total_failed or discovery_skips
+                else MassTransferTask.Status.SUCCESS
             )
             message = f"{study_count} studies, {total_series} series ({', '.join(parts)})."
+            if discovery_skips:
+                message += f" {len(discovery_skips)} studies skipped due to invalid DICOM metadata."
 
         return {
             "status": status,
@@ -843,78 +869,21 @@ class MassTransferTaskProcessor(DicomTaskProcessor):
             raise DicomError("Mass transfer requires at least one include filter.")
 
         found: dict[str, DiscoveredSeries] = {}
+        self._discovery_skips = []
 
         for mf in include_filters:
             studies = self._find_studies(operator, mf, start, end)
 
             for study in studies:
-                if mf.modality and mf.modality not in study.ModalitiesInStudy:
-                    continue
-
-                if mf.study_description and not _dicom_match(
-                    mf.study_description, study.StudyDescription
-                ):
-                    continue
-
-                if mf.institution_name and mf.apply_institution_on_study:
-                    if not self._study_has_institution(operator, study, mf.institution_name):
-                        continue
-
-                # Exact client-side age filtering using actual StudyDate and
-                # PatientBirthDate (the query birth date range is approximate).
-                birth_date = study.PatientBirthDate
-                has_age_filter = mf.min_age is not None or mf.max_age is not None
-                if birth_date and study.StudyDate and has_age_filter:
-                    age = _age_at_study(birth_date, study.StudyDate)
-                    if mf.min_age is not None and age < mf.min_age:
-                        continue
-                    if mf.max_age is not None and age > mf.max_age:
-                        continue
-
-                series_query = QueryDataset.create(
-                    PatientID=study.PatientID,
-                    StudyInstanceUID=study.StudyInstanceUID,
-                )
-                series_query.dataset.InstitutionName = ""
-
-                series_list = list(operator.find_series(series_query))
-
-                for series in series_list:
-                    series_uid = series.SeriesInstanceUID
-                    if not series_uid:
-                        continue
-
-                    if series_uid in found:
-                        continue
-
-                    series_number = _parse_int(series.get("SeriesNumber"), default=None)
-                    study_dt = _study_datetime(study)
-                    discovered = DiscoveredSeries(
-                        patient_id=str(study.PatientID),
-                        accession_number=str(study.get("AccessionNumber", "")),
-                        study_instance_uid=str(study.StudyInstanceUID),
-                        series_instance_uid=str(series_uid),
-                        modality=str(series.Modality),
-                        study_description=str(study.get("StudyDescription", "")),
-                        series_description=str(series.get("SeriesDescription", "")),
-                        series_number=series_number,
-                        study_datetime=study_dt,
-                        institution_name=str(series.get("InstitutionName", "")),
-                        number_of_images=_parse_int(
-                            series.get("NumberOfSeriesRelatedInstances"), default=0
-                        )
-                        or 0,
-                        patient_birth_date=birth_date,
-                    )
-
-                    if not _series_matches_filter(
-                        discovered,
-                        mf,
-                        check_institution=not mf.apply_institution_on_study,
-                    ):
-                        continue
-
-                    found[series_uid] = discovered
+                try:
+                    self._discover_study_series(operator, study, mf, found)
+                except ValueError as err:
+                    # Some PACS return studies with non-conformant date/time
+                    # metadata; skip them but keep the partition going and
+                    # surface a warning on the task.
+                    uid = str(study.StudyInstanceUID)
+                    logger.warning("Skipping study %s with invalid DICOM metadata: %s", uid, err)
+                    self._discovery_skips.append(f"{uid}: {err}")
 
         if not exclude_filters:
             return list(found.values())
@@ -926,6 +895,78 @@ class MassTransferTaskProcessor(DicomTaskProcessor):
                 _series_matches_filter(series, mf, age_permissive=True) for mf in exclude_filters
             )
         ]
+
+    def _discover_study_series(
+        self,
+        operator: DicomOperator,
+        study: ResultDataset,
+        mf: FilterSpec,
+        found: dict[str, DiscoveredSeries],
+    ) -> None:
+        """Collect all series of *study* matching the include filter *mf* into *found*."""
+        if mf.modality and mf.modality not in study.ModalitiesInStudy:
+            return
+
+        if mf.study_description and not _dicom_match(mf.study_description, study.StudyDescription):
+            return
+
+        if mf.institution_name and mf.apply_institution_on_study:
+            if not self._study_has_institution(operator, study, mf.institution_name):
+                return
+
+        # Exact client-side age filtering using actual StudyDate and
+        # PatientBirthDate (the query birth date range is approximate).
+        birth_date = study.PatientBirthDate
+        has_age_filter = mf.min_age is not None or mf.max_age is not None
+        if birth_date and study.StudyDate and has_age_filter:
+            age = _age_at_study(birth_date, study.StudyDate)
+            if mf.min_age is not None and age < mf.min_age:
+                return
+            if mf.max_age is not None and age > mf.max_age:
+                return
+
+        series_query = QueryDataset.create(
+            PatientID=study.PatientID,
+            StudyInstanceUID=study.StudyInstanceUID,
+        )
+        series_query.dataset.InstitutionName = ""
+
+        series_list = list(operator.find_series(series_query))
+
+        for series in series_list:
+            series_uid = series.SeriesInstanceUID
+            if not series_uid:
+                continue
+
+            if series_uid in found:
+                continue
+
+            series_number = _parse_int(series.get("SeriesNumber"), default=None)
+            study_dt = _study_datetime(study)
+            discovered = DiscoveredSeries(
+                patient_id=str(study.PatientID),
+                accession_number=str(study.get("AccessionNumber", "")),
+                study_instance_uid=str(study.StudyInstanceUID),
+                series_instance_uid=str(series_uid),
+                modality=str(series.Modality),
+                study_description=str(study.get("StudyDescription", "")),
+                series_description=str(series.get("SeriesDescription", "")),
+                series_number=series_number,
+                study_datetime=study_dt,
+                institution_name=str(series.get("InstitutionName", "")),
+                number_of_images=_parse_int(series.get("NumberOfSeriesRelatedInstances"), default=0)
+                or 0,
+                patient_birth_date=birth_date,
+            )
+
+            if not _series_matches_filter(
+                discovered,
+                mf,
+                check_institution=not mf.apply_institution_on_study,
+            ):
+                continue
+
+            found[series_uid] = discovered
 
     def _find_studies(
         self,

--- a/adit/mass_transfer/tests/test_processor.py
+++ b/adit/mass_transfer/tests/test_processor.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -46,6 +47,17 @@ def _make_study(study_uid: str, study_date: str = "20240101") -> ResultDataset:
     ds.PatientID = "PAT1"
     ds.ModalitiesInStudy = ["CT"]
     return ResultDataset(ds)
+
+
+def _set_nonconformant(ds: Dataset, keyword: str, value: str) -> None:
+    """Assign a non-conformant value as a PACS can return it over the network.
+
+    pydicom validates (and warns) on assignment, but network-decoded datasets
+    bypass that validation, so suppress the warning here.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        setattr(ds, keyword, value)
 
 
 def _fake_export_success(*args, **kwargs):
@@ -685,6 +697,74 @@ def test_discover_series_exclude_by_institution(mocker: MockerFixture):
 
     series_uids = {s.series_instance_uid for s in result}
     assert series_uids == {"1.2.3.901"}
+
+
+def test_discover_series_salvages_malformed_study_time(mocker: MockerFixture):
+    """A non-conformant StudyTime (as returned by some PACS) falls back to midnight."""
+    processor = _make_processor(mocker)
+    processor.mass_task.partition_start = datetime(2024, 1, 1, 0, 0)
+    processor.mass_task.partition_end = datetime(2024, 1, 1, 23, 59, 59)
+
+    operator = mocker.create_autospec(DicomOperator)
+    operator.server = mocker.MagicMock(max_search_results=200)
+
+    study = _make_study("1.2.3.100")
+    # TM only allows a fractional part after full HHMMSS, so HHMM.fff is invalid
+    _set_nonconformant(study.dataset, "StudyTime", "1113.672")
+    operator.find_studies.return_value = [study]
+    operator.find_series.return_value = [_make_series_result("1.2.3.201")]
+
+    result = processor._discover_series(operator, [_make_filter(modality="CT")])
+
+    assert len(result) == 1
+    assert result[0].study_datetime == datetime(2024, 1, 1, 0, 0, 0)
+
+
+def test_discover_series_skips_study_with_malformed_study_date(mocker: MockerFixture):
+    """A study with an unparseable StudyDate is skipped instead of failing the whole task."""
+    processor = _make_processor(mocker)
+    processor.mass_task.partition_start = datetime(2024, 1, 1, 0, 0)
+    processor.mass_task.partition_end = datetime(2024, 1, 1, 23, 59, 59)
+
+    operator = mocker.create_autospec(DicomOperator)
+    operator.server = mocker.MagicMock(max_search_results=200)
+
+    bad_study = _make_study("1.2.3.666")
+    _set_nonconformant(bad_study.dataset, "StudyDate", "20143822")
+    good_study = _make_study("1.2.3.100")
+    operator.find_studies.return_value = [bad_study, good_study]
+    operator.find_series.return_value = [_make_series_result("1.2.3.201")]
+
+    result = processor._discover_series(operator, [_make_filter(modality="CT")])
+
+    assert [s.study_instance_uid for s in result] == ["1.2.3.100"]
+
+    summary = processor._build_task_summary(1, 1, 1, 0, 0, {})
+    assert summary["status"] == MassTransferTask.Status.WARNING
+    assert "1.2.3.666" in summary["log"]
+
+
+def test_discover_series_all_studies_malformed_warns(mocker: MockerFixture):
+    """Even if nothing is transferable, skipped studies must surface as a warning."""
+    processor = _make_processor(mocker)
+    processor.mass_task.partition_start = datetime(2024, 1, 1, 0, 0)
+    processor.mass_task.partition_end = datetime(2024, 1, 1, 23, 59, 59)
+
+    operator = mocker.create_autospec(DicomOperator)
+    operator.server = mocker.MagicMock(max_search_results=200)
+
+    bad_study = _make_study("1.2.3.666")
+    _set_nonconformant(bad_study.dataset, "StudyDate", "20143822")
+    operator.find_studies.return_value = [bad_study]
+    operator.find_series.return_value = [_make_series_result("1.2.3.201")]
+
+    result = processor._discover_series(operator, [_make_filter(modality="CT")])
+
+    assert result == []
+
+    summary = processor._build_task_summary(0, 0, 0, 0, 0, {})
+    assert summary["status"] == MassTransferTask.Status.WARNING
+    assert "skipped" in summary["message"].lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Some PACS return studies with non-conformant date/time values (seen in production: StudyDate with an invalid month, StudyTime `1113.672`). `_discover_series` raised a bare `ValueError` from pydicom's `DA`/`TM` parsing, which nothing caught, so the **whole daily partition task failed** (mass transfer job 2, tasks 8543/9805) and stayed failed on every retry.
- StudyTime: fall back to midnight when it cannot be parsed (it is only used for folder naming).
- StudyDate (or anything else still unparseable): skip that single study instead of failing the task. Skipped studies are listed in the task log and the task finishes as `WARNING`, so the omission stays visible.
- Refactor: per-study discovery extracted into `_discover_study_series()` so the skip is a single `try/except` around it.

## Test plan
- [x] New tests in `adit/mass_transfer/tests/test_processor.py`: malformed StudyTime is salvaged, malformed StudyDate skips only that study with WARNING, all-malformed partition warns instead of failing
- [x] `adit/mass_transfer/tests/test_processor.py` green (102 passed), ruff + pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed study time values by safely falling back to midnight.
  - Studies with invalid date information are skipped instead of stopping the entire transfer.
  - Transfer results now clearly report skipped studies and their reasons.

- **Warnings**
  - Partitions with skipped studies are marked as warnings, including when no data can be processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->