### PR TITLE
Bump adit-radis-shared to 0.28.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ constraint-dependencies = ["autobahn<25.11.1"]
 
 [tool.uv.sources]
 adit-client = { path = "./adit-client", editable = true }
-adit-radis-shared = { git = "https://github.com/openradx/adit-radis-shared.git", tag = "0.28.0" }
+adit-radis-shared = { git = "https://github.com/openradx/adit-radis-shared.git", tag = "0.28.1" }
 
 [tool.pyright]
 ignore = ["**/migrations", "**/*.ipynb"]

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?tag=0.28.0" },
+    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?tag=0.28.1" },
     { name = "adrf", specifier = ">=0.1.9" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "asyncinotify", specifier = ">=4.2.0" },
@@ -223,7 +223,7 @@ requires-dist = [
 [[package]]
 name = "adit-radis-shared"
 version = "0.0.0"
-source = { git = "https://github.com/openradx/adit-radis-shared.git?tag=0.28.0#15e8bb3ad885e1838e832cf506531a8dc74faacf" }
+source = { git = "https://github.com/openradx/adit-radis-shared.git?tag=0.28.1#c0f1bba83d2a372d1b4f955aab1e91bba0b2f7ee" }
 dependencies = [
     { name = "channels" },
     { name = "crispy-bootstrap5" },


### PR DESCRIPTION
Picks up openradx/adit-radis-shared#247, which fixes the flake that failed #408's first CI run.

`run_worker_once()` converted the app's connector unconditionally:

```python
with app.replace_connector(app.connector.get_worker_connector()):
```

`DjangoConnector.get_worker_connector()` *returns* a `PsycopgConnector`, which has no such method of its own — so whenever the connector was already worker-capable, every caller in the session failed at once with `AttributeError`. ADIT is the only consumer of this helper, so it is the only repo that ever hit it.

Lock delta is a single line: `adit-radis-shared 15e8bb3a → c0f1bba8`.

## Verification

- `pytest -m "not acceptance"`: **900 passed, 3 xfailed**
- `ruff check`, `pyright`: clean

Not run locally: the Playwright acceptance tests (they need the dev containers built).

## Related

RADIS counterpart: openradx/radis#298

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4uip5n3TwDXh6tHuoDsuc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the shared component dependency to version 0.28.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->